### PR TITLE
Fix date going back if `ElapsedTime` overflows

### DIFF
--- a/Python examples/10 - Streaming with timestamps.py
+++ b/Python examples/10 - Streaming with timestamps.py
@@ -43,9 +43,8 @@ class timeStamps:
         return self.__startTime
     @StartTime.setter
     def StartTime(self, Value):
-        if self.__startTime is None:
-            adder = (-1 * (time.timezone))
-            self.__startTime = Value + adder
+        adder = (-1 * (time.timezone))
+        self.__startTime = Value + adder
     @property    
     def lastTime(self):
         return datetime.utcfromtimestamp(self.__timeBuffer[-1]).strftime('%H:%M:%S')


### PR DESCRIPTION
On some sound level meters, the `ElapsedTime` sequence overflows only after reaching 86,400 seconds (24 hours). If `lastTime` is formatted to show the date, then it will suddenly change back to the date of when the stream was started when overflow occurs.

When this happens, the `StartTime` sequence is updated to the current time. It can be used with the overflowed values of the `ElapsedTime` sequence to always get the correct date. Removing the condition that `__startTime` can only be set once achieves this.